### PR TITLE
fix(nextra): replace Head with Next App Router viewport metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Github, Linkedin, Twitter } from "lucide-react";
-import { Head } from "nextra/components";
 import { getPageMap } from "nextra/page-map";
 import { Layout, Navbar, ThemeSwitch } from "nextra-theme-blog";
 import "nextra-theme-blog/style.css";
@@ -35,6 +34,13 @@ export const metadata: Metadata = {
   authors: [{ name: "Marc Klingen" }],
 };
 
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f8f8f5" },
+    { media: "(prefers-color-scheme: dark)", color: "#100f0f" },
+  ],
+};
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -44,12 +50,6 @@ export default async function RootLayout({
 
   return (
     <html lang="en" suppressHydrationWarning>
-      <Head
-        backgroundColor={{
-          dark: "#100f0f",
-          light: "#f8f8f5",
-        }}
-      />
       <body>
         <Layout nextThemes={{ defaultTheme: "light" }}>
           <Navbar pageMap={pageMap}>


### PR DESCRIPTION
### Motivation
- The build was failing during TypeScript checking with the error that `Head` from `nextra/components` "cannot be used as a JSX component" under Next.js 16 / React 19 type-checking. 
- The intent is to preserve the light/dark theme color metadata previously provided via `<Head backgroundColor={...} />` while removing the JSX component that triggers the typing incompatibility. 
- A minimal code change to move theme color metadata into the Next App Router-native export avoids the typing mismatch and lets the site compile and prerender.

### Description
- Removed the import and JSX usage of `Head` from `nextra/components` in `app/layout.tsx` and kept the rest of the layout intact. 
- Added `Viewport` to the imported `next` types and introduced `export const viewport: Viewport = { themeColor: [...] }` to declare light/dark theme colors. 
- This moves the previous `backgroundColor` values into Next's `viewport.themeColor` metadata so the same theme intent is preserved without using `Head`. 
- Changes were committed with message `fix: replace nextra Head with Next viewport metadata`.

### Testing
- Ran `pnpm exec tsc --noEmit` which completed successfully with no TypeScript errors. 
- Ran `pnpm run build` which completed successfully and performed compilation, static page generation, and `next-sitemap` postbuild steps. 
- The adjusted build output shows successful compilation and prerendering of app routes with no TypeScript JSX errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae38e5f49c832f8052218b6d15300e)