### PR TITLE
Enable Turbopack build and dev runs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,11 @@ const withNextra = nextra({
 export default withNextra({
   reactStrictMode: true,
   cleanDistDir: true,
+  turbopack: {
+    resolveAlias: {
+      'next-mdx-import-source-file': './mdx-components.jsx'
+    }
+  },
   redirects: async () => [
     ...nonPermanentRedirects.map(([source, destination]) => ({
       source,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "homepage": "https://marcklingen.com",
   "scripts": {
-    "dev": "next dev --webpack -p 3334",
-    "build": "next build --webpack",
+    "dev": "next dev --turbopack -p 3334",
+    "build": "next build --turbopack",
     "postbuild": "next-sitemap",
     "start": "next start -p 3334"
   },


### PR DESCRIPTION
Summary
- point the npm scripts at Turbopack for dev/build to activate the new bundler
- configure `next-mdx-import-source-file` alias so Turbopack resolves the shared MDX component

Testing
- Not run (not requested)